### PR TITLE
Single role

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,16 @@ Your config file can be either a yaml or json file.
 The example yaml (`iam_config.yaml`) looks this:
 
 ```yaml
+iam_role_name: iam_role_name
+
 athena:
   write: false
 
-glue_job:
-  iam_role_name: iam_role_name
+glue_job: true
 
-s3:
+secrets: true
+
+s3: 
   read_only:
     - test_bucket_read_only/*
 
@@ -67,12 +70,12 @@ Whilst the example json (`iam_config.json`) looks like this:
 
 ```json
 {
+  "iam_role_name": "iam_role_name",
   "athena": {
     "write": false
   },
-  "glue_job": {
-    "iam_role_name": "iam_role_name"
-  },
+  "glue_job": true,
+  "secrets": true,
   "s3": {
     "read_only": [
       "test_bucket_read_only/*"
@@ -88,12 +91,15 @@ Whilst the example json (`iam_config.json`) looks like this:
   }
 }
 ```
+- **iam_role_name:** The role name of your airflow job; required if you want to run glue jobs or access secrets.
 
-- **athena:** only has one key value pair. `write` which is either true or false. If `false` then only read access to Athena (cannot create, delete or alter tables, databases and partitions). If `true` then the role will also have the ability to do stuff like CTAS queries, `DROP TABLE`, `CREATE DATABASE`, etc.
+- **athena:** Only has one key value pair. `write` which is either true or false. If `false` then only read access to Athena (cannot create, delete or alter tables, databases and partitions). If `true` then the role will also have the ability to do stuff like CTAS queries, `DROP TABLE`, `CREATE DATABASE`, etc.
 
-- **run_glue_job:** Allows role to run glue jobs. Requires an `iam_role_name` parameter which should be the name of the iam role that is going to use this policy.
+- **glue_job:** Boolean; must be set to `true` to allow role to run glue jobs. If `false` or absent role will not be able to run glue jobs.
 
-- **s3:** Has can have up to 3 keys: `read_only`, `write_only` and `read_write`. Each key describes the level of access you want your iam policy to have with each s3 path. More details below:
+- **secrets:** Boolean; must be set to `true` to allow role to access secrets from AWS Parameter Store. If `false` or absent role will not be able to access secrets.
+
+- **s3:** Can have up to 3 keys: `read_only`, `write_only` and `read_write`. Each key describes the level of access you want your iam policy to have with each s3 path. More details below:
   
   - **read_only:** A list of s3 paths that the iam_role should be able to access (read only). Each item in the list should either be a path to a object or finish with `/*` to denote that it can access everything within that directory. _Note the S3 paths don't start with `s3://` in the config._
 

--- a/examples/iam_config.json
+++ b/examples/iam_config.json
@@ -1,10 +1,10 @@
 {
+  "iam_role_name": "iam_role_name",
   "athena": {
     "write": false
   },
-  "glue_job": {
-    "iam_role_name": "iam_role_name"
-  },
+  "glue_job": true,
+  "secrets": true,
   "s3": {
     "read_only": [
       "test_bucket_read_only/*"

--- a/examples/iam_config.yaml
+++ b/examples/iam_config.yaml
@@ -3,7 +3,9 @@ iam_role_name: iam_role_name
 athena:
   write: false
 
-glue_job: false
+glue_job: true
+
+secrets: true
 
 s3: 
   read_only:

--- a/examples/iam_config.yaml
+++ b/examples/iam_config.yaml
@@ -1,8 +1,9 @@
+iam_role_name: iam_role_name
+
 athena:
   write: false
 
-glue_job:
-  iam_role_name: iam_role_name
+glue_job: false
 
 s3: 
   read_only:

--- a/examples/iam_policy.json
+++ b/examples/iam_policy.json
@@ -192,13 +192,40 @@
         {
             "Sid": "list",
             "Action": [
-                "s3:ListBucket"
+                "s3:ListBucket",
+                "s3:ListAllMyBuckets",
+                "s3:GetBucketLocation"
             ],
             "Effect": "Allow",
             "Resource": [
-                "arn:aws:s3:::test_bucket_write_only",
+                "arn:aws:s3:::alpha-athena-query-dump",
+                "arn:aws:s3:::test_bucket_read_only",
                 "arn:aws:s3:::test_bucket_read_write",
-                "arn:aws:s3:::test_bucket_read_only"
+                "arn:aws:s3:::test_bucket_write_only"
+            ]
+        },
+        {
+            "Sid": "readParams",
+            "Effect": "Allow",
+            "Action": [
+                "ssm:DescribeParameters",
+                "ssm:GetParameter",
+                "ssm:GetParameters",
+                "ssm:GetParameterHistory",
+                "ssm:GetParametersByPath"
+            ],
+            "Resource": [
+                "arn:aws:ssm:*:*:parameter/alpha/airflow/iam_role_name/*"
+            ]
+        },
+        {
+            "Sid": "allowDecrypt",
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt"
+            ],
+            "Resource": [
+                "arn:aws:kms:::key/*"
             ]
         }
     ]

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -29,10 +29,10 @@ def build_iam_policy(config):
         list_buckets.append(athena_dump_bucket)
         
     # Test to run glue jobs
-    if 'glue_job' in config:
+    if 'glue_job' in config and config['glue_job']:
         iam['Statement'].extend(iam_lookup['glue_job'])
         # Add ability to pass itself to glue job
-        pass_role = get_pass_role_to_glue_policy(config['glue_job']['iam_role_name'])
+        pass_role = get_pass_role_to_glue_policy(config['iam_role_name'])
         iam['Statement'].append(pass_role)
 
     # Deal with read only access

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -8,6 +8,7 @@ from iam_builder.templates import (
     get_write_only_policy,
     get_read_write_policy,
     get_s3_list_bucket_policy,
+    get_secrets,
     athena_dump_bucket
 )
 

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -62,5 +62,10 @@ def build_iam_policy(config):
     if list_buckets:
         s3_list_bucket = get_s3_list_bucket_policy(list_buckets)
         iam['Statement'].append(s3_list_bucket)
+    
+    if 'secrets' in config and config['secrets']:
+        secrets_statement = get_secrets(config['iam_role_name'])
+        iam['Statement'].append(secrets_statement)
+        iam['Statement'].extend(iam_lookup['decrypt_statement'])
 
     return iam

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -164,6 +164,18 @@ iam_lookup = {
                 "arn:aws:s3:::aws-glue-*"
             ]
         }
+    ],
+    "decrypt_statement": [
+        {
+            "Sid": "allowDecrypt",
+            "Effect": "Allow",
+            "Action": [
+                "kms:Decrypt"
+            ],
+            "Resource": [
+                "arn:aws:kms:::key/*"
+            ]
+        }
     ]
 }
 

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -263,3 +263,20 @@ def get_s3_list_bucket_policy(list_of_buckets):
 def add_s3_arn_prefix(paths):
     arn_prefix = 'arn:aws:s3:::'
     return [arn_prefix + p for p in paths]
+
+def get_secrets(iam_role):
+    statement = {
+        "Sid": "readParams",
+        "Effect": "Allow",
+        "Action": [
+            "ssm:DescribeParameters",
+            "ssm:GetParameter",
+            "ssm:GetParameters",
+            "ssm:GetParameterHistory",
+            "ssm:GetParametersByPath"
+        ],
+        "Resource": [
+            f"arn:aws:ssm:*:*:parameter/alpha/airflow/{iam_role}/*"
+        ]
+    }
+    return statement


### PR DESCRIPTION
Now we have to define a single role `iam_role_name` and use a boolean to state whether we want glue jobs or secrets.

This won't be backwards compatible, but my first thought is that shouldn't matter really (since people run this once to generate their `iam_policy.json` rather than have it as part of a pipeline).