### PR TITLE
Enable glue job logging

### DIFF
--- a/examples/iam_policy.json
+++ b/examples/iam_policy.json
@@ -110,7 +110,11 @@
             "Sid": "CanGetLogs",
             "Effect": "Allow",
             "Action": [
-                "logs:GetLogEvents"
+                "logs:GetLogEvents",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams"
             ],
             "Resource": [
                 "arn:aws:logs:*:*:/aws-glue/*"
@@ -120,6 +124,7 @@
             "Sid": "CanGetCloudWatchLogs",
             "Effect": "Allow",
             "Action": [
+                "cloudwatch:PutMetricData",
                 "cloudwatch:GetMetricData",
                 "cloudwatch:ListDashboards"
             ],

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -145,7 +145,11 @@ iam_lookup = {
             "Sid": "CanGetLogs",
             "Effect": "Allow",
             "Action": [
-                "logs:GetLogEvents"
+                "logs:GetLogEvents",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams"
             ],
             "Resource": [
                 "arn:aws:logs:*:*:/aws-glue/*"
@@ -155,6 +159,7 @@ iam_lookup = {
             "Sid": "CanGetCloudWatchLogs",
             "Effect": "Allow",
             "Action": [
+                "cloudwatch:PutMetricData",
                 "cloudwatch:GetMetricData",
                 "cloudwatch:ListDashboards"
             ],

--- a/tests/expected_policy/all_config.json
+++ b/tests/expected_policy/all_config.json
@@ -135,7 +135,11 @@
             "Sid": "CanGetLogs",
             "Effect": "Allow",
             "Action": [
-                "logs:GetLogEvents"
+                "logs:GetLogEvents",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams"
             ],
             "Resource": [
                 "arn:aws:logs:*:*:/aws-glue/*"
@@ -145,6 +149,7 @@
             "Sid": "CanGetCloudWatchLogs",
             "Effect": "Allow",
             "Action": [
+                "cloudwatch:PutMetricData",
                 "cloudwatch:GetMetricData",
                 "cloudwatch:ListDashboards"
             ],

--- a/tests/expected_policy/glue_job.json
+++ b/tests/expected_policy/glue_job.json
@@ -26,7 +26,11 @@
             "Sid": "CanGetLogs",
             "Effect": "Allow",
             "Action": [
-                "logs:GetLogEvents"
+                "logs:GetLogEvents",
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents",
+                "logs:DescribeLogStreams"
             ],
             "Resource": [
                 "arn:aws:logs:*:*:/aws-glue/*"
@@ -36,6 +40,7 @@
             "Sid": "CanGetCloudWatchLogs",
             "Effect": "Allow",
             "Action": [
+                "cloudwatch:PutMetricData",
                 "cloudwatch:GetMetricData",
                 "cloudwatch:ListDashboards"
             ],


### PR DESCRIPTION
Adds:
"cloudwatch:PutMetricData"
"logs:CreateLogGroup",
"logs:CreateLogStream",
"logs:PutLogEvents",
"logs:DescribeLogStreams"

Some like DescribeLogStreams might be unnecessary - Gets in the wider policy are probably unnecessary too.