### PR TITLE
Update Athena policy templates

### DIFF
--- a/examples/iam_policy.json
+++ b/examples/iam_policy.json
@@ -2,40 +2,50 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "CanListObjectsInAthenaBuckets",
+            "Sid": "AllowListAllMyBuckets",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowListBucket",
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*",
+                "arn:aws:s3:::moj-analytics-lookup-tables",
                 "arn:aws:s3:::alpha-athena-query-dump"
             ]
         },
         {
-            "Sid": "CanWriteToDefaultAthenaBucket",
+            "Sid": "AllowGetObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::moj-analytics-lookup-tables/*"
+            ]
+        },
+        {
+            "Sid": "AllowGetPutObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*"
+                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
             ]
         },
         {
-            "Sid": "CanReadAthenaExamples",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::athena-examples*"
-            ]
-        },
-        {
-            "Sid": "CanReadWriteAthenaDumpFolder",
+            "Sid": "AllowGetPutDeleteObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
@@ -47,7 +57,7 @@
             ]
         },
         {
-            "Sid": "ReadAthenaGlue",
+            "Sid": "AllowReadAthenaGlue",
             "Effect": "Allow",
             "Action": [
                 "athena:BatchGetNamedQuery",

--- a/examples/iam_policy.json
+++ b/examples/iam_policy.json
@@ -41,7 +41,7 @@
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
+                "arn:aws:s3:::aws-athena-query-results-*"
             ]
         },
         {

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -47,7 +47,7 @@ iam_lookup = {
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
+                "arn:aws:s3:::aws-athena-query-results-*"
             ]
         },
         {

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -8,40 +8,50 @@ athena_dump_bucket = "alpha-athena-query-dump"
 iam_lookup = {
     "athena_read_access": [
         {
-            "Sid": "CanListObjectsInAthenaBuckets",
+            "Sid": "AllowListAllMyBuckets",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowListBucket",
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*",
+                "arn:aws:s3:::moj-analytics-lookup-tables",
                 "arn:aws:s3:::" + athena_dump_bucket
             ]
         },
         {
-            "Sid": "CanWriteToDefaultAthenaBucket",
+            "Sid": "AllowGetObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::moj-analytics-lookup-tables/*"
+            ]
+        },
+        {
+            "Sid": "AllowGetPutObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*"
+                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
             ]
         },
         {
-            "Sid": "CanReadAthenaExamples",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::athena-examples*"
-            ]
-        },
-        {
-            "Sid": "CanReadWriteAthenaDumpFolder",
+            "Sid": "AllowGetPutDeleteObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
@@ -53,7 +63,7 @@ iam_lookup = {
             ]
         },
         {
-            "Sid": "ReadAthenaGlue",
+            "Sid": "AllowReadAthenaGlue",
             "Effect": "Allow",
             "Action": [
                 "athena:BatchGetNamedQuery",
@@ -94,7 +104,7 @@ iam_lookup = {
     ],
     "athena_write_access": [
         {
-            "Sid": "WriteAthenaGlue",
+            "Sid": "AllowWriteAthenaGlue",
             "Effect": "Allow",
             "Action": [
                 "athena:DeleteNamedQuery",

--- a/tests/expected_policy/all_config.json
+++ b/tests/expected_policy/all_config.json
@@ -2,40 +2,50 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "CanListObjectsInAthenaBuckets",
+            "Sid": "AllowListAllMyBuckets",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowListBucket",
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*",
+                "arn:aws:s3:::moj-analytics-lookup-tables",
                 "arn:aws:s3:::alpha-athena-query-dump"
             ]
         },
         {
-            "Sid": "CanWriteToDefaultAthenaBucket",
+            "Sid": "AllowGetObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::moj-analytics-lookup-tables/*"
+            ]
+        },
+        {
+            "Sid": "AllowGetPutObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*"
+                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
             ]
         },
         {
-            "Sid": "CanReadAthenaExamples",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::athena-examples*"
-            ]
-        },
-        {
-            "Sid": "CanReadWriteAthenaDumpFolder",
+            "Sid": "AllowGetPutDeleteObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
@@ -47,7 +57,7 @@
             ]
         },
         {
-            "Sid": "ReadAthenaGlue",
+            "Sid": "AllowReadAthenaGlue",
             "Effect": "Allow",
             "Action": [
                 "athena:BatchGetNamedQuery",
@@ -86,7 +96,7 @@
             ]
         },
         {
-            "Sid": "WriteAthenaGlue",
+            "Sid": "AllowWriteAthenaGlue",
             "Effect": "Allow",
             "Action": [
                 "athena:DeleteNamedQuery",

--- a/tests/expected_policy/all_config.json
+++ b/tests/expected_policy/all_config.json
@@ -41,7 +41,7 @@
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
+                "arn:aws:s3:::aws-athena-query-results-*"
             ]
         },
         {

--- a/tests/expected_policy/athena_full_access.json
+++ b/tests/expected_policy/athena_full_access.json
@@ -2,40 +2,50 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "CanListObjectsInAthenaBuckets",
+            "Sid": "AllowListAllMyBuckets",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowListBucket",
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*",
+                "arn:aws:s3:::moj-analytics-lookup-tables",
                 "arn:aws:s3:::alpha-athena-query-dump"
             ]
         },
         {
-            "Sid": "CanWriteToDefaultAthenaBucket",
+            "Sid": "AllowGetObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::moj-analytics-lookup-tables/*"
+            ]
+        },
+        {
+            "Sid": "AllowGetPutObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*"
+                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
             ]
         },
         {
-            "Sid": "CanReadAthenaExamples",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::athena-examples*"
-            ]
-        },
-        {
-            "Sid": "CanReadWriteAthenaDumpFolder",
+            "Sid": "AllowGetPutDeleteObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
@@ -47,7 +57,7 @@
             ]
         },
         {
-            "Sid": "ReadAthenaGlue",
+            "Sid": "AllowReadAthenaGlue",
             "Effect": "Allow",
             "Action": [
                 "athena:BatchGetNamedQuery",
@@ -86,7 +96,7 @@
             ]
         },
         {
-            "Sid": "WriteAthenaGlue",
+            "Sid": "AllowWriteAthenaGlue",
             "Effect": "Allow",
             "Action": [
                 "athena:DeleteNamedQuery",

--- a/tests/expected_policy/athena_full_access.json
+++ b/tests/expected_policy/athena_full_access.json
@@ -41,7 +41,7 @@
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
+                "arn:aws:s3:::aws-athena-query-results-*"
             ]
         },
         {

--- a/tests/expected_policy/athena_read_only.json
+++ b/tests/expected_policy/athena_read_only.json
@@ -2,40 +2,50 @@
     "Version": "2012-10-17",
     "Statement": [
         {
-            "Sid": "CanListObjectsInAthenaBuckets",
+            "Sid": "AllowListAllMyBuckets",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowListBucket",
             "Effect": "Allow",
             "Action": [
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*",
+                "arn:aws:s3:::moj-analytics-lookup-tables",
                 "arn:aws:s3:::alpha-athena-query-dump"
             ]
         },
         {
-            "Sid": "CanWriteToDefaultAthenaBucket",
+            "Sid": "AllowGetObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::moj-analytics-lookup-tables/*"
+            ]
+        },
+        {
+            "Sid": "AllowGetPutObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*"
+                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
             ]
         },
         {
-            "Sid": "CanReadAthenaExamples",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::athena-examples*"
-            ]
-        },
-        {
-            "Sid": "CanReadWriteAthenaDumpFolder",
+            "Sid": "AllowGetPutDeleteObject",
             "Effect": "Allow",
             "Action": [
                 "s3:GetObject",
@@ -47,7 +57,7 @@
             ]
         },
         {
-            "Sid": "ReadAthenaGlue",
+            "Sid": "AllowReadAthenaGlue",
             "Effect": "Allow",
             "Action": [
                 "athena:BatchGetNamedQuery",

--- a/tests/expected_policy/athena_read_only.json
+++ b/tests/expected_policy/athena_read_only.json
@@ -41,7 +41,7 @@
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-593291632749-eu-west-1/*"
+                "arn:aws:s3:::aws-athena-query-results-*"
             ]
         },
         {


### PR DESCRIPTION
This PR will:
- remove permissions to `ListBucket` on `arn:aws:s3:::aws-athena-query-results-*`
- make the `arn:aws:s3:::aws-athena-query-results-*` resource more specific, instead of using a wildcard
- add permissions to `ListBucket` and `GetObject` on `moj-analytics-lookup-tables/*`
- make sid naming more consistent 
- update expected policies for tests involving Athena

See also https://github.com/moj-analytical-services/data-engineering-infrastructure/pull/40.