### PR TITLE
Workflow python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v1
         with:
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -6,7 +6,7 @@ iam_base_template = {
     "Statement": []
 }
 
-athena_dump_bucket = "alpha-athena-query-dump"
+athena_dump_bucket = "mojap-athena-query-dump"
 
 iam_lookup = {
     "athena_read_access": [

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -6,7 +6,7 @@ iam_base_template = {
     "Statement": []
 }
 
-athena_dump_bucket = "mojap-athena-query-dump"
+athena_dump_bucket = "alpha-athena-query-dump"
 
 iam_lookup = {
     "athena_read_access": [


### PR DESCRIPTION
Problems with git workflow because of the nested 'version' in the yaml. Changing to 'python-version' should fix it. 