### PR TITLE
Change athena dump bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist
+__pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Changed default query dump bucket from alpha-athena-query-dump to mojap-athena-query-dump
 - Can select multiple query dump buckets by putting a list in config
 - Added a test for multiple query dump buckets
+- Added some type hints
 
 ## v3.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## v3.8.0
+## v4.0.0
 
 - Added details on how to update on PyPi
 - Added Github action for linting
-- Changed target bucket for temporary files from Athena queries: now mojap-athena-query-dump rather than alpha-athena-query-dump
+- Target bucket for Athena query temporary files can now be selected in config (or left out to use default)
+- Changed default query dump bucket from alpha-athena-query-dump to mojap-athena-query-dump
+- Can select multiple query dump buckets by putting a list in config
+- Added a test for multiple query dump buckets
 
 ## v3.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v3.8.0
+
+- Added details on how to update on PyPi
+- Added Github action for linting
+- Changed target bucket for temporary files from Athena queries: now mojap-athena-query-dump rather than alpha-athena-query-dump
+
 ## v3.7.0
 
 - Updated `parameterized` module dependency to align with `etl_manager`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Actions Status](https://github.com/moj-analytical-services/iam_builder/workflows/IAM%20Builder/badge.svg)](https://github.com/moj-analytical-services/iam_builder/actions)
 
-A python script to generate an IAM policy based on an yaml or json configuration.
+A python script to generate an IAM policy based on a yaml or json configuration.
 
 To install:
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Whilst the example json (`iam_config.json`) looks like this:
 
 ## How to update
 
-When updating IAM builder, make sure to change the version number in `pyproject.yaml` and describe the change in `CHANGELOG.md`.
+When updating IAM builder, make sure to change the version number in `pyproject.toml` and describe the change in `CHANGELOG.md`.
 
 If you have changed any dependencies in `pyproject.yaml`, run `poetry update` to update `poetry.lock`.
 

--- a/examples/iam_config.json
+++ b/examples/iam_config.json
@@ -1,7 +1,8 @@
 {
   "iam_role_name": "iam_role_name",
   "athena": {
-    "write": false
+    "write": false,
+    "dump_bucket": ["mojap-athena-query-dump"]
   },
   "glue_job": true,
   "secrets": true,

--- a/examples/iam_config.yaml
+++ b/examples/iam_config.yaml
@@ -2,6 +2,8 @@ iam_role_name: iam_role_name
 
 athena:
   write: false
+  dump_bucket: 
+    - mojap-athena-query-dump
 
 glue_job: true
 

--- a/examples/iam_config.yaml
+++ b/examples/iam_config.yaml
@@ -2,7 +2,7 @@ iam_role_name: iam_role_name
 
 athena:
   write: false
-  dump_bucket: 
+  dump_bucket:
     - mojap-athena-query-dump
 
 glue_job: true

--- a/examples/iam_policy.json
+++ b/examples/iam_policy.json
@@ -20,7 +20,7 @@
             ],
             "Resource": [
                 "arn:aws:s3:::moj-analytics-lookup-tables",
-                "arn:aws:s3:::alpha-athena-query-dump"
+                "arn:aws:s3:::mojap-athena-query-dump"
             ]
         },
         {
@@ -53,7 +53,7 @@
                 "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:::alpha-athena-query-dump/${aws:userid}/*"
+                "arn:aws:s3:::mojap-athena-query-dump/${aws:userid}/*"
             ]
         },
         {
@@ -224,7 +224,7 @@
             ],
             "Effect": "Allow",
             "Resource": [
-                "arn:aws:s3:::alpha-athena-query-dump",
+                "arn:aws:s3:::mojap-athena-query-dump",
                 "arn:aws:s3:::test_bucket_read_only",
                 "arn:aws:s3:::test_bucket_read_write",
                 "arn:aws:s3:::test_bucket_write_only"

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -9,7 +9,6 @@ from iam_builder.templates import (
     get_read_write_policy,
     get_s3_list_bucket_policy,
     get_secrets,
-    athena_dump_bucket,
 )
 
 
@@ -20,19 +19,34 @@ def build_iam_policy(config):
     iam = copy.deepcopy(iam_base_template)
 
     list_buckets = []
+
+    # Create lookup dict based on selected or default Athena dump bucket or buckets
+    try:
+        dump_bucket = config["athena"]["dump_bucket"]
+
+        if not isinstance(dump_bucket, list):
+            dump_bucket = [dump_bucket]
+
+        dump_bucket = [bucket.replace("_", "-") for bucket in dump_bucket]
+
+    except KeyError:
+        dump_bucket = ["mojap-athena-query-dump"]
+
+    lookup = iam_lookup(dump_bucket)
+
     # Define if has athena permission
     if "athena" in config:
-        iam["Statement"].extend(iam_lookup["athena_read_access"])
+        iam["Statement"].extend(lookup["athena_read_access"])
 
         if config["athena"]["write"]:
-            iam["Statement"].extend(iam_lookup["athena_write_access"])
+            iam["Statement"].extend(lookup["athena_write_access"])
 
         # Needed for s3tools package
-        list_buckets.append(athena_dump_bucket)
+        list_buckets.extend(dump_bucket)
 
     # Test to run glue jobs
     if "glue_job" in config and config["glue_job"]:
-        iam["Statement"].extend(iam_lookup["glue_job"])
+        iam["Statement"].extend(lookup["glue_job"])
         # Add ability to pass itself to glue job
         pass_role = get_pass_role_to_glue_policy(config["iam_role_name"])
         iam["Statement"].append(pass_role)
@@ -68,6 +82,6 @@ def build_iam_policy(config):
     if "secrets" in config and config["secrets"]:
         secrets_statement = get_secrets(config["iam_role_name"])
         iam["Statement"].append(secrets_statement)
-        iam["Statement"].extend(iam_lookup["decrypt_statement"])
+        iam["Statement"].extend(lookup["decrypt_statement"])
 
     return iam

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -13,11 +13,11 @@ from iam_builder.templates import (
 )
 
 
-def build_iam_policy(config):
+def build_iam_policy(config: dict) -> dict:
     """
     Takes a configuration for an IAM policy and returns the policy as a dict.
     """
-    iam = copy.deepcopy(iam_base_template)
+    iam: dict = copy.deepcopy(iam_base_template)
 
     list_buckets = []
 
@@ -40,20 +40,20 @@ def build_iam_policy(config):
     if "glue_job" in config and config["glue_job"]:
         iam["Statement"].extend(iam_lookup["glue_job"])
         # Add ability to pass itself to glue job
-        pass_role = get_pass_role_to_glue_policy(config["iam_role_name"])
+        pass_role: dict = get_pass_role_to_glue_policy(config["iam_role_name"])
         iam["Statement"].append(pass_role)
 
     # Deal with read only access
     if "s3" in config:
         if "read_only" in config["s3"]:
-            s3_read_only = get_read_only_policy(config["s3"]["read_only"])
+            s3_read_only: dict = get_read_only_policy(config["s3"]["read_only"])
             iam["Statement"].append(s3_read_only)
 
             # Get buckets to list
             list_buckets.extend([p.split("/")[0] for p in config["s3"]["read_only"]])
 
         if "write_only" in config["s3"]:
-            s3_write_only = get_write_only_policy(config["s3"]["write_only"])
+            s3_write_only: dict = get_write_only_policy(config["s3"]["write_only"])
             iam["Statement"].append(s3_write_only)
 
             # Get buckets to list
@@ -61,18 +61,18 @@ def build_iam_policy(config):
 
         # Deal with write only access
         if "read_write" in config["s3"]:
-            s3_read_write = get_read_write_policy(config["s3"]["read_write"])
+            s3_read_write: dict = get_read_write_policy(config["s3"]["read_write"])
             iam["Statement"].append(s3_read_write)
 
             # Get buckets to list
             list_buckets.extend([p.split("/")[0] for p in config["s3"]["read_write"]])
 
     if list_buckets:
-        s3_list_bucket = get_s3_list_bucket_policy(list_buckets)
+        s3_list_bucket: dict = get_s3_list_bucket_policy(list_buckets)
         iam["Statement"].append(s3_list_bucket)
 
     if "secrets" in config and config["secrets"]:
-        secrets_statement = get_secrets(config["iam_role_name"])
+        secrets_statement: dict = get_secrets(config["iam_role_name"])
         iam["Statement"].append(secrets_statement)
         iam["Statement"].extend(iam_lookup["decrypt_statement"])
 

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -40,20 +40,20 @@ def build_iam_policy(config: dict) -> dict:
     if "glue_job" in config and config["glue_job"]:
         iam["Statement"].extend(iam_lookup["glue_job"])
         # Add ability to pass itself to glue job
-        pass_role: dict = get_pass_role_to_glue_policy(config["iam_role_name"])
+        pass_role = get_pass_role_to_glue_policy(config["iam_role_name"])
         iam["Statement"].append(pass_role)
 
     # Deal with read only access
     if "s3" in config:
         if "read_only" in config["s3"]:
-            s3_read_only: dict = get_read_only_policy(config["s3"]["read_only"])
+            s3_read_only = get_read_only_policy(config["s3"]["read_only"])
             iam["Statement"].append(s3_read_only)
 
             # Get buckets to list
             list_buckets.extend([p.split("/")[0] for p in config["s3"]["read_only"]])
 
         if "write_only" in config["s3"]:
-            s3_write_only: dict = get_write_only_policy(config["s3"]["write_only"])
+            s3_write_only = get_write_only_policy(config["s3"]["write_only"])
             iam["Statement"].append(s3_write_only)
 
             # Get buckets to list
@@ -61,18 +61,18 @@ def build_iam_policy(config: dict) -> dict:
 
         # Deal with write only access
         if "read_write" in config["s3"]:
-            s3_read_write: dict = get_read_write_policy(config["s3"]["read_write"])
+            s3_read_write = get_read_write_policy(config["s3"]["read_write"])
             iam["Statement"].append(s3_read_write)
 
             # Get buckets to list
             list_buckets.extend([p.split("/")[0] for p in config["s3"]["read_write"]])
 
     if list_buckets:
-        s3_list_bucket: dict = get_s3_list_bucket_policy(list_buckets)
+        s3_list_bucket = get_s3_list_bucket_policy(list_buckets)
         iam["Statement"].append(s3_list_bucket)
 
     if "secrets" in config and config["secrets"]:
-        secrets_statement: dict = get_secrets(config["iam_role_name"])
+        secrets_statement = get_secrets(config["iam_role_name"])
         iam["Statement"].append(secrets_statement)
         iam["Statement"].extend(iam_lookup["decrypt_statement"])
 

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -113,7 +113,7 @@ iam_lookup = {
 }
 
 
-def get_athena_read_access(dump_bucket):
+def get_athena_read_access(dump_bucket: list) -> dict:
     """Creates segments of IAM policy needed for reading
     from one or more Athena query dump buckets
 
@@ -225,7 +225,7 @@ def get_athena_read_access(dump_bucket):
     return athena_read_access
 
 
-def get_pass_role_to_glue_policy(iam_role):
+def get_pass_role_to_glue_policy(iam_role: str) -> dict:
     policy = {
                 "Sid": "PassRoleToGlueService",
                 "Effect": "Allow",
@@ -244,7 +244,7 @@ def get_pass_role_to_glue_policy(iam_role):
     return policy
 
 
-def get_read_only_policy(list_of_s3_paths):
+def get_read_only_policy(list_of_s3_paths: list) -> dict:
     list_of_s3_paths = add_s3_arn_prefix(list_of_s3_paths)
     policy = {
             "Sid": "readonly",
@@ -259,7 +259,7 @@ def get_read_only_policy(list_of_s3_paths):
     return policy
 
 
-def get_write_only_policy(list_of_s3_paths):
+def get_write_only_policy(list_of_s3_paths: list) -> dict:
     list_of_s3_paths = add_s3_arn_prefix(list_of_s3_paths)
     policy = {
             "Sid": "writeonly",
@@ -276,7 +276,7 @@ def get_write_only_policy(list_of_s3_paths):
     return policy
 
 
-def get_read_write_policy(list_of_s3_paths):
+def get_read_write_policy(list_of_s3_paths: list) -> dict:
     list_of_s3_paths = add_s3_arn_prefix(list_of_s3_paths)
     policy = {
         "Sid": "readwrite",
@@ -296,7 +296,7 @@ def get_read_write_policy(list_of_s3_paths):
     return policy
 
 
-def get_s3_list_bucket_policy(list_of_buckets):
+def get_s3_list_bucket_policy(list_of_buckets: list) -> dict:
     list_of_buckets = add_s3_arn_prefix(list_of_buckets)
     policy = {
         "Sid": "list",
@@ -311,12 +311,12 @@ def get_s3_list_bucket_policy(list_of_buckets):
     return policy
 
 
-def add_s3_arn_prefix(paths):
+def add_s3_arn_prefix(paths: list) -> list:
     arn_prefix = "arn:aws:s3:::"
     return [arn_prefix + p for p in paths]
 
 
-def get_secrets(iam_role):
+def get_secrets(iam_role: str) -> dict:
     statement = {
         "Sid": "readParams",
         "Effect": "Allow",

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -6,207 +6,219 @@ iam_base_template = {
     "Statement": []
 }
 
-athena_dump_bucket = "mojap-athena-query-dump"
 
-iam_lookup = {
-    "athena_read_access": [
-        {
-            "Sid": "AllowListAllMyBuckets",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetBucketLocation",
-                "s3:ListAllMyBuckets"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "AllowListBucket",
-            "Effect": "Allow",
-            "Action": [
-                "s3:ListBucket"
-            ],
-            "Resource": [
-                "arn:aws:s3:::moj-analytics-lookup-tables",
-                "arn:aws:s3:::" + athena_dump_bucket
-            ]
-        },
-        {
-            "Sid": "AllowGetObject",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::moj-analytics-lookup-tables/*"
-            ]
-        },
-        {
-            "Sid": "AllowGetPutObject",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::aws-athena-query-results-*"
-            ]
-        },
-        {
-            "Sid": "AllowGetPutDeleteObject",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject",
-                "s3:DeleteObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::" + athena_dump_bucket + "/${aws:userid}/*"
-            ]
-        },
-        {
-            "Sid": "AllowReadAthenaGlue",
-            "Effect": "Allow",
-            "Action": [
-                "athena:BatchGetNamedQuery",
-                "athena:BatchGetQueryExecution",
-                "athena:GetNamedQuery",
-                "athena:GetQueryExecution",
-                "athena:GetQueryResults",
-                "athena:GetQueryResultsStream",
-                "athena:GetWorkGroup",
-                "athena:ListNamedQueries",
-                "athena:ListWorkGroups",
-                "athena:StartQueryExecution",
-                "athena:StopQueryExecution",
-                "athena:CancelQueryExecution",
-                "athena:GetCatalogs",
-                "athena:GetExecutionEngine",
-                "athena:GetExecutionEngines",
-                "athena:GetNamespace",
-                "athena:GetNamespaces",
-                "athena:GetTable",
-                "athena:GetTables",
-                "athena:RunQuery",
-                "glue:GetDatabase",
-                "glue:GetDatabases",
-                "glue:GetTable",
-                "glue:GetTables",
-                "glue:GetPartition",
-                "glue:GetPartitions",
-                "glue:BatchGetPartition",
-                "glue:GetCatalogImportStatus",
-                "glue:GetUserDefinedFunction",
-                "glue:GetUserDefinedFunctions"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ],
-    "athena_write_access": [
-        {
-            "Sid": "AllowWriteAthenaGlue",
-            "Effect": "Allow",
-            "Action": [
-                "athena:DeleteNamedQuery",
-                "glue:BatchCreatePartition",
-                "glue:BatchDeletePartition",
-                "glue:BatchDeleteTable",
-                "glue:CreateDatabase",
-                "glue:CreatePartition",
-                "glue:CreateTable",
-                "glue:DeleteDatabase",
-                "glue:DeletePartition",
-                "glue:DeleteTable",
-                "glue:UpdateDatabase",
-                "glue:UpdatePartition",
-                "glue:UpdateTable",
-                "glue:CreateUserDefinedFunction",
-                "glue:DeleteUserDefinedFunction",
-                "glue:UpdateUserDefinedFunction"
-            ],
-            "Resource": [
-                "*"
-            ]
-        }
-    ],
-    "glue_job": [
-        {
-            "Sid": "GlueJobActions",
-            "Effect": "Allow",
-            "Action": [
-                "glue:BatchStopJobRun",
-                "glue:CreateJob",
-                "glue:DeleteJob",
-                "glue:GetJob",
-                "glue:GetJobs",
-                "glue:GetJobRun",
-                "glue:GetJobRuns",
-                "glue:StartJobRun",
-                "glue:UpdateJob",
-                "glue:ListJobs",
-                "glue:BatchGetJobs",
-                "glue:GetJobBookmark"
-            ],
-            "Resource": [
-                "*"
-            ]
-        },
-        {
-            "Sid": "CanGetLogs",
-            "Effect": "Allow",
-            "Action": [
-                "logs:GetLogEvents",
-                "logs:CreateLogGroup",
-                "logs:CreateLogStream",
-                "logs:PutLogEvents",
-                "logs:DescribeLogStreams"
-            ],
-            "Resource": [
-                "arn:aws:logs:*:*:/aws-glue/*"
-            ]
-        },
-        {
-            "Sid": "CanGetCloudWatchLogs",
-            "Effect": "Allow",
-            "Action": [
-                "cloudwatch:PutMetricData",
-                "cloudwatch:GetMetricData",
-                "cloudwatch:ListDashboards"
-            ],
-            "Resource": [
-                "*"    
-            ]
-        },
-        {
-            "Sid": "CanReadGlueStuff",
-            "Effect": "Allow",
-            "Action": [
-                "s3:GetObject",
-                "s3:PutObject"
-            ],
-            "Resource": [
-                "arn:aws:s3:::aws-glue-*/*",
-                "arn:aws:s3:::*/*aws-glue-*/*",
-                "arn:aws:s3:::aws-glue-*"
-            ]
-        }
-    ],
-    "decrypt_statement": [
-        {
-            "Sid": "allowDecrypt",
-            "Effect": "Allow",
-            "Action": [
-                "kms:Decrypt"
-            ],
-            "Resource": [
-                "arn:aws:kms:::key/*"
-            ]
-        }
+def iam_lookup(athena_dump_bucket):
+    """Creates a full lookup policy based on the selected dump bucket
+
+    Parameters
+    ----------
+    athena_dump_bucket (str/list): bucket name or names for Athena query dump
+    """
+    # prepare sections of iam lookup that depend on dump bucket or buckets
+    allow_list_bucket_resources = ["arn:aws:s3:::moj-analytics-lookup-tables"]
+    allow_list_bucket_resources.extend([
+        "arn:aws:s3:::" + bucket for bucket in athena_dump_bucket
+        ])
+    allow_get_put_delete_resources = [
+        "arn:aws:s3:::" + bucket + "/${aws:userid}/*" for bucket in athena_dump_bucket
     ]
-}
+
+    # insert prepared sections into full iam lookup
+    lookup = {
+        "athena_read_access": [
+            {
+                "Sid": "AllowListAllMyBuckets",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetBucketLocation",
+                    "s3:ListAllMyBuckets"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            },
+            {
+                "Sid": "AllowListBucket",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket"
+                ],
+                "Resource": allow_list_bucket_resources
+            },
+            {
+                "Sid": "AllowGetObject",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::moj-analytics-lookup-tables/*"
+                ]
+            },
+            {
+                "Sid": "AllowGetPutObject",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::aws-athena-query-results-*"
+                ]
+            },
+            {
+                "Sid": "AllowGetPutDeleteObject",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject"
+                ],
+                "Resource": allow_get_put_delete_resources
+            },
+            {
+                "Sid": "AllowReadAthenaGlue",
+                "Effect": "Allow",
+                "Action": [
+                    "athena:BatchGetNamedQuery",
+                    "athena:BatchGetQueryExecution",
+                    "athena:GetNamedQuery",
+                    "athena:GetQueryExecution",
+                    "athena:GetQueryResults",
+                    "athena:GetQueryResultsStream",
+                    "athena:GetWorkGroup",
+                    "athena:ListNamedQueries",
+                    "athena:ListWorkGroups",
+                    "athena:StartQueryExecution",
+                    "athena:StopQueryExecution",
+                    "athena:CancelQueryExecution",
+                    "athena:GetCatalogs",
+                    "athena:GetExecutionEngine",
+                    "athena:GetExecutionEngines",
+                    "athena:GetNamespace",
+                    "athena:GetNamespaces",
+                    "athena:GetTable",
+                    "athena:GetTables",
+                    "athena:RunQuery",
+                    "glue:GetDatabase",
+                    "glue:GetDatabases",
+                    "glue:GetTable",
+                    "glue:GetTables",
+                    "glue:GetPartition",
+                    "glue:GetPartitions",
+                    "glue:BatchGetPartition",
+                    "glue:GetCatalogImportStatus",
+                    "glue:GetUserDefinedFunction",
+                    "glue:GetUserDefinedFunctions"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ],
+        "athena_write_access": [
+            {
+                "Sid": "AllowWriteAthenaGlue",
+                "Effect": "Allow",
+                "Action": [
+                    "athena:DeleteNamedQuery",
+                    "glue:BatchCreatePartition",
+                    "glue:BatchDeletePartition",
+                    "glue:BatchDeleteTable",
+                    "glue:CreateDatabase",
+                    "glue:CreatePartition",
+                    "glue:CreateTable",
+                    "glue:DeleteDatabase",
+                    "glue:DeletePartition",
+                    "glue:DeleteTable",
+                    "glue:UpdateDatabase",
+                    "glue:UpdatePartition",
+                    "glue:UpdateTable",
+                    "glue:CreateUserDefinedFunction",
+                    "glue:DeleteUserDefinedFunction",
+                    "glue:UpdateUserDefinedFunction"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            }
+        ],
+        "glue_job": [
+            {
+                "Sid": "GlueJobActions",
+                "Effect": "Allow",
+                "Action": [
+                    "glue:BatchStopJobRun",
+                    "glue:CreateJob",
+                    "glue:DeleteJob",
+                    "glue:GetJob",
+                    "glue:GetJobs",
+                    "glue:GetJobRun",
+                    "glue:GetJobRuns",
+                    "glue:StartJobRun",
+                    "glue:UpdateJob",
+                    "glue:ListJobs",
+                    "glue:BatchGetJobs",
+                    "glue:GetJobBookmark"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            },
+            {
+                "Sid": "CanGetLogs",
+                "Effect": "Allow",
+                "Action": [
+                    "logs:GetLogEvents",
+                    "logs:CreateLogGroup",
+                    "logs:CreateLogStream",
+                    "logs:PutLogEvents",
+                    "logs:DescribeLogStreams"
+                ],
+                "Resource": [
+                    "arn:aws:logs:*:*:/aws-glue/*"
+                ]
+            },
+            {
+                "Sid": "CanGetCloudWatchLogs",
+                "Effect": "Allow",
+                "Action": [
+                    "cloudwatch:PutMetricData",
+                    "cloudwatch:GetMetricData",
+                    "cloudwatch:ListDashboards"
+                ],
+                "Resource": [
+                    "*"
+                ]
+            },
+            {
+                "Sid": "CanReadGlueStuff",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject"
+                ],
+                "Resource": [
+                    "arn:aws:s3:::aws-glue-*/*",
+                    "arn:aws:s3:::*/*aws-glue-*/*",
+                    "arn:aws:s3:::aws-glue-*"
+                ]
+            }
+        ],
+        "decrypt_statement": [
+            {
+                "Sid": "allowDecrypt",
+                "Effect": "Allow",
+                "Action": [
+                    "kms:Decrypt"
+                ],
+                "Resource": [
+                    "arn:aws:kms:::key/*"
+                ]
+            }
+        ]
+    }
+    return lookup
 
 
 def get_pass_role_to_glue_policy(iam_role):

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -6,7 +6,7 @@ iam_base_template = {
     "Statement": []
 }
 
-athena_dump_bucket = "alpha-athena-query-dump"
+athena_dump_bucket = "mojap-athena-query-dump"
 
 iam_lookup = {
     "athena_read_access": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "3.8.0"
+version = "4.0.0"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "3.7.0"
+version = "3.8.0"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"

--- a/tests/expected_policy/all_config.json
+++ b/tests/expected_policy/all_config.json
@@ -20,7 +20,7 @@
             ],
             "Resource": [
                 "arn:aws:s3:::moj-analytics-lookup-tables",
-                "arn:aws:s3:::alpha-athena-query-dump"
+                "arn:aws:s3:::mojap-athena-query-dump"
             ]
         },
         {
@@ -53,7 +53,7 @@
                 "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:::alpha-athena-query-dump/${aws:userid}/*"
+                "arn:aws:s3:::mojap-athena-query-dump/${aws:userid}/*"
             ]
         },
         {
@@ -249,7 +249,7 @@
             ],
             "Effect": "Allow",
             "Resource": [
-                "arn:aws:s3:::alpha-athena-query-dump",
+                "arn:aws:s3:::mojap-athena-query-dump",
                 "arn:aws:s3:::test_bucket_read_only",
                 "arn:aws:s3:::test_bucket_read_write",
                 "arn:aws:s3:::test_bucket_write_only"

--- a/tests/expected_policy/athena_full_access.json
+++ b/tests/expected_policy/athena_full_access.json
@@ -20,7 +20,7 @@
             ],
             "Resource": [
                 "arn:aws:s3:::moj-analytics-lookup-tables",
-                "arn:aws:s3:::alpha-athena-query-dump"
+                "arn:aws:s3:::mojap-athena-query-dump"
             ]
         },
         {
@@ -53,7 +53,7 @@
                 "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:::alpha-athena-query-dump/${aws:userid}/*"
+                "arn:aws:s3:::mojap-athena-query-dump/${aws:userid}/*"
             ]
         },
         {
@@ -141,8 +141,8 @@
             ],
             "Effect": "Allow",
             "Resource": [
-                "arn:aws:s3:::alpha-athena-query-dump",
-                "arn:aws:s3:::alpha-test-iam-builer"
+                "arn:aws:s3:::alpha-test-iam-builer",
+                "arn:aws:s3:::mojap-athena-query-dump"
             ]
         }
     ]

--- a/tests/expected_policy/athena_read_only.json
+++ b/tests/expected_policy/athena_read_only.json
@@ -20,7 +20,7 @@
             ],
             "Resource": [
                 "arn:aws:s3:::moj-analytics-lookup-tables",
-                "arn:aws:s3:::alpha-athena-query-dump"
+                "arn:aws:s3:::mojap-athena-query-dump"
             ]
         },
         {
@@ -53,7 +53,7 @@
                 "s3:DeleteObject"
             ],
             "Resource": [
-                "arn:aws:s3:::alpha-athena-query-dump/${aws:userid}/*"
+                "arn:aws:s3:::mojap-athena-query-dump/${aws:userid}/*"
             ]
         },
         {
@@ -116,8 +116,8 @@
             ],
             "Effect": "Allow",
             "Resource": [
-                "arn:aws:s3:::alpha-athena-query-dump",
-                "arn:aws:s3:::alpha-test-iam-builer"
+                "arn:aws:s3:::alpha-test-iam-builer",
+                "arn:aws:s3:::mojap-athena-query-dump"
             ]
         }
     ]

--- a/tests/expected_policy/athena_two_dumps.json
+++ b/tests/expected_policy/athena_two_dumps.json
@@ -1,0 +1,152 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AllowListAllMyBuckets",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetBucketLocation",
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowListBucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::moj-analytics-lookup-tables",
+                "arn:aws:s3:::alpha-athena-query-dump",
+                "arn:aws:s3:::mojap-athena-query-dump"
+            ]
+        },
+        {
+            "Sid": "AllowGetObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::moj-analytics-lookup-tables/*"
+            ]
+        },
+        {
+            "Sid": "AllowGetPutObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::aws-athena-query-results-*"
+            ]
+        },
+        {
+            "Sid": "AllowGetPutDeleteObject",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::alpha-athena-query-dump/${aws:userid}/*",
+                "arn:aws:s3:::mojap-athena-query-dump/${aws:userid}/*"
+            ]
+        },
+        {
+            "Sid": "AllowReadAthenaGlue",
+            "Effect": "Allow",
+            "Action": [
+                "athena:BatchGetNamedQuery",
+                "athena:BatchGetQueryExecution",
+                "athena:GetNamedQuery",
+                "athena:GetQueryExecution",
+                "athena:GetQueryResults",
+                "athena:GetQueryResultsStream",
+                "athena:GetWorkGroup",
+                "athena:ListNamedQueries",
+                "athena:ListWorkGroups",
+                "athena:StartQueryExecution",
+                "athena:StopQueryExecution",
+                "athena:CancelQueryExecution",
+                "athena:GetCatalogs",
+                "athena:GetExecutionEngine",
+                "athena:GetExecutionEngines",
+                "athena:GetNamespace",
+                "athena:GetNamespaces",
+                "athena:GetTable",
+                "athena:GetTables",
+                "athena:RunQuery",
+                "glue:GetDatabase",
+                "glue:GetDatabases",
+                "glue:GetTable",
+                "glue:GetTables",
+                "glue:GetPartition",
+                "glue:GetPartitions",
+                "glue:BatchGetPartition",
+                "glue:GetCatalogImportStatus",
+                "glue:GetUserDefinedFunction",
+                "glue:GetUserDefinedFunctions"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "AllowWriteAthenaGlue",
+            "Effect": "Allow",
+            "Action": [
+                "athena:DeleteNamedQuery",
+                "glue:BatchCreatePartition",
+                "glue:BatchDeletePartition",
+                "glue:BatchDeleteTable",
+                "glue:CreateDatabase",
+                "glue:CreatePartition",
+                "glue:CreateTable",
+                "glue:DeleteDatabase",
+                "glue:DeletePartition",
+                "glue:DeleteTable",
+                "glue:UpdateDatabase",
+                "glue:UpdatePartition",
+                "glue:UpdateTable",
+                "glue:CreateUserDefinedFunction",
+                "glue:DeleteUserDefinedFunction",
+                "glue:UpdateUserDefinedFunction"
+            ],
+            "Resource": [
+                "*"
+            ]
+        },
+        {
+            "Sid": "readonly",
+            "Action": [
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:GetObjectVersion"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::alpha-test-iam-builer/db/*"
+            ]
+        },
+        {
+            "Sid": "list",
+            "Action": [
+                "s3:ListBucket",
+                "s3:ListAllMyBuckets",
+                "s3:GetBucketLocation"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "arn:aws:s3:::alpha-athena-query-dump",
+                "arn:aws:s3:::alpha-test-iam-builer",
+                "arn:aws:s3:::mojap-athena-query-dump"
+            ]
+        }
+    ]
+}

--- a/tests/test_config/athena_two_dumps.yaml
+++ b/tests/test_config/athena_two_dumps.yaml
@@ -1,0 +1,9 @@
+athena:
+  write: true
+  dump_bucket: 
+    - alpha-athena-query-dump
+    - mojap-athena-query-dump
+
+s3:
+  read_only:
+    - alpha-test-iam-builer/db/*

--- a/tests/test_config/athena_two_dumps.yaml
+++ b/tests/test_config/athena_two_dumps.yaml
@@ -1,6 +1,6 @@
 athena:
   write: true
-  dump_bucket: 
+  dump_bucket:
     - alpha-athena-query-dump
     - mojap-athena-query-dump
 

--- a/tests/test_iam_builder.py
+++ b/tests/test_iam_builder.py
@@ -57,7 +57,6 @@ class TestConfigOutputs(unittest.TestCase):
     """
     Test different configs
     """
-    maxDiff = None
     
     @parameterized.expand(
         [

--- a/tests/test_iam_builder.py
+++ b/tests/test_iam_builder.py
@@ -66,6 +66,7 @@ class TestConfigOutputs(unittest.TestCase):
             "sub_folder_multi_access",
             "athena_read_only",
             "athena_full_access",
+            "athena_two_dumps",
             "glue_job",
             "all_config",
         ]

--- a/tests/test_iam_builder.py
+++ b/tests/test_iam_builder.py
@@ -57,7 +57,8 @@ class TestConfigOutputs(unittest.TestCase):
     """
     Test different configs
     """
-
+    maxDiff = None
+    
     @parameterized.expand(
         [
             "read_only",
@@ -70,6 +71,7 @@ class TestConfigOutputs(unittest.TestCase):
             "all_config",
         ]
     )
+
     def test_config_output(self, config_name):
         assert_config_as_expected(self, config_name)
 

--- a/tests/test_iam_builder.py
+++ b/tests/test_iam_builder.py
@@ -57,7 +57,7 @@ class TestConfigOutputs(unittest.TestCase):
     """
     Test different configs
     """
-    
+
     @parameterized.expand(
         [
             "read_only",
@@ -71,7 +71,6 @@ class TestConfigOutputs(unittest.TestCase):
             "all_config",
         ]
     )
-
     def test_config_output(self, config_name):
         assert_config_as_expected(self, config_name)
 


### PR DESCRIPTION
This renames alpha-athena-query-dump bucket to mojap-athena-query-dump bucket wherever it appears. This new bucket is created and managed by [data-engineering-infra](https://github.com/moj-analytical-services/data-engineering-infra). 

Also reordered the resources list in some of the tests to match the policies generated.
