### PR TITLE
Implement backwards secrets compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v4.2.1
+
+- implemented backwards compatibility for secrets
+
 ## v4.2.0
 
 - added readwrite option for secrets

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -83,9 +83,11 @@ def build_iam_policy(config: dict) -> dict:  # noqa: C901
         iam["Statement"].append(s3_list_bucket)
 
     if "secrets" in config:
-        readwrite = config["secrets"] == "readwrite"
-        secrets_statement = get_secrets(config["iam_role_name"], readwrite)
-        iam["Statement"].append(secrets_statement)
-        iam["Statement"].extend(iam_lookup["decrypt_statement"])
+        secrets = config["secrets"]
+        if isinstance(secrets, str) or secrets:
+            readwrite = secrets == "readwrite"
+            secrets_statement = get_secrets(config["iam_role_name"], readwrite)
+            iam["Statement"].append(secrets_statement)
+            iam["Statement"].extend(iam_lookup["decrypt_statement"])
 
     return iam

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "4.2.0"
+version = "4.2.1"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
Fixing backwards compatibility where `secrets` is set to `false` in an IAM config file. These changes mean the `iam_role_name` does not need to be set in a config where `secrets` is set to `false`. This is to replicate the behaviour in versions prior to `v4.2.0`.