### PR TITLE
AP-3398: add role_duration_seconds to iam_schema.json

### DIFF
--- a/iam_builder/schemas/iam_schema.json
+++ b/iam_builder/schemas/iam_schema.json
@@ -73,6 +73,10 @@
                     }
                 }
             }
+        },
+        "role_duration_seconds":{
+            "description": "Max duration role can be assumed for in seconds",
+            "type": "integer"
         }
     }
 }


### PR DESCRIPTION
Airflow users require the ability to extend the role duration past the default of 1 hour, this change adds `role_duration_seconds` to the `iam_schema.json` in order for the value to be passed into the Pulumi Role.