### PR TITLE
🏴󠁧󠁢󠁥󠁮󠁧󠁿 Adding London region to Bedrock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v4.7.0
+
+- Add London region for Amazon Bedrock
+
 ## v4.6.0
 
 - Add Amazon Bedrock permissions

--- a/examples/iam_policy.json
+++ b/examples/iam_policy.json
@@ -339,7 +339,8 @@
                 "StringEquals": {
                     "aws:RequestedRegion": [
                         "eu-central-1",
-                        "eu-west-3"
+                        "eu-west-3",
+                        "eu-west-2"
                     ]
                 }
             }

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -160,7 +160,8 @@ iam_lookup = {
                 "StringEquals": {
                     "aws:RequestedRegion": [
                         "eu-central-1",
-                        "eu-west-3"
+                        "eu-west-3",
+                        "eu-west-2"
                     ]
                 }
             }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "4.6.0"
+version = "4.7.0"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"

--- a/tests/expected_policy/all_config.json
+++ b/tests/expected_policy/all_config.json
@@ -323,7 +323,8 @@
               "StringEquals": {
                   "aws:RequestedRegion": [
                       "eu-central-1",
-                      "eu-west-3"
+                      "eu-west-3",
+                      "eu-west-2"
                   ]
               }
           }


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/analytical-platform/issues/4310

Adding London region to Bedrock since [London](https://docs.aws.amazon.com/bedrock/latest/userguide/bedrock-regions.html) is now a supported region. 