### PR TITLE
🧪 Update schema

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,9 +1,9 @@
 {
   "features": {
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "1.6.1",
-      "resolved": "ghcr.io/devcontainers/features/python@sha256:d449aea663ea23ac4a7968719d5920dd57128f0429cd8e216849d5afe67651fb",
-      "integrity": "sha256:d449aea663ea23ac4a7968719d5920dd57128f0429cd8e216849d5afe67651fb"
+      "version": "1.6.4",
+      "resolved": "ghcr.io/devcontainers/features/python@sha256:046a904b940e1793327369f57f4b0a7d89febbdd9e77086a70feffdfa564f888",
+      "integrity": "sha256:046a904b940e1793327369f57f4b0a7d89febbdd9e77086a70feffdfa564f888"
     }
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v4.9.0
+
+- Add `external_iam_role` to allow Airflow Pulumi tests to pass
+
 ## v4.8.0
 
 - Updates standard athena policy to add 'glue:GetTableVersions'

--- a/iam_builder/schemas/iam_schema.json
+++ b/iam_builder/schemas/iam_schema.json
@@ -8,6 +8,10 @@
             "description": "The role name of the airflow job",
             "type": "string"
         },
+        "external_iam_role": {
+            "description": "The ARN of an external IAM role to assume",
+            "type": "string"
+        },
         "athena": {
             "description": "Athena configuration",
             "additionalProperties": false,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "4.9.0-rc1"
+version = "4.9.0"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "4.8.0"
+version = "4.9.0-rc1"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
> [!CAUTION]
> EXPERIMENTAL

This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5457
- Adds `external_iam_role` which allows Airflow jobs to assume external IAM roles via IRSA

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 