### PR TITLE
updated pkgversion and fixed warning in pypi release

### DIFF
--- a/.github/workflows/poetry-pypi-release.yml
+++ b/.github/workflows/poetry-pypi-release.yml
@@ -36,4 +36,4 @@ jobs:
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          packages_dir: artifact/
+          packages-dir: artifact/

--- a/.github/workflows/poetry-pypi-release.yml
+++ b/.github/workflows/poetry-pypi-release.yml
@@ -37,3 +37,4 @@ jobs:
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           packages-dir: artifact/
+          skip-existing: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "4.10.1"
+version = "4.10.2"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
- Updated pkg version to 4.10.2 for release
- Fixed deprecated packages_dir in publish workflow
- Added option to skip existing releases, should avoid future errors