### PR TITLE
Fixing publish action

### DIFF
--- a/.github/workflows/poetry-pypi-release.yml
+++ b/.github/workflows/poetry-pypi-release.yml
@@ -17,7 +17,7 @@ jobs:
           pip install poetry
           poetry build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08  #v4.6.0
         with:
           path: ./dist
 
@@ -31,7 +31,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  #v4.1.8
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The v3 versions of upload and download artefacts have been deprecated and removed. Updating to new versions.