### PR TITLE
StartCalculationExecution policy added to cadet-deployer role

### DIFF
--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -139,7 +139,8 @@ iam_lookup = {
                 "athena:GetSession",
                 "athena:GetSessionStatus",
                 "athena:ListSession",
-                "athena:TerminateSession"
+                "athena:TerminateSession",
+                "athena:StartCalculationExecution"
             ],
             "Resource": [
                 "arn:aws:athena:*:*:datacatalog/*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "4.15.0"
+version = "4.16.0"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"

--- a/tests/expected_policy/cadet_deployer.json
+++ b/tests/expected_policy/cadet_deployer.json
@@ -41,7 +41,8 @@
               "athena:GetSession",
               "athena:GetSessionStatus",
               "athena:ListSession",
-              "athena:TerminateSession"
+              "athena:TerminateSession",
+              "athena:StartCalculationExecution"
           ],
           "Resource": [
               "arn:aws:athena:*:*:datacatalog/*",


### PR DESCRIPTION
This PR is related to Athena Spark Initial Testing
[#6640](https://github.com/ministryofjustice/analytical-platform/issues/6640)

This is to address the below error in airflow DAG.
`[2025-02-26, 09:39:31 UTC] {{pod_manager.py:228}} INFO - [0m09:39:31  dbt.adapters.athena.constants adapter: Encountered client error: An error occurred (AccessDeniedException) when calling the StartCalculationExecution operation: You are not authorized to perform: athena:StartCalculationExecution on the resource. After your AWS administrator or you have updated your permissions, please try again.
`