### PR TITLE
Add glue catalog policy functionality to standard IAM builder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## v4.17.0
+
+- Add intial changes to prepare for removal of broad glue permissions in iam_builder 5.0 (coming soon)
+- Implement tests/validation for new functionality
+
 ## v4.12.0
 
 - Add Glue Superuser Policy for Create-A-Derived-Table deployments.

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -13,9 +13,11 @@ from iam_builder.templates import (
     get_secrets,
     get_kms_permissions,
     get_secretsmanager_read_only_policy,
+    get_glue_permissions,
 )
 from iam_builder.iam_schema import validate_iam
-from iam_builder.exceptions import PrivilegedRoleValidationError
+from iam_builder.exceptions import PrivilegedRoleValidationError, IAMValidationError
+import re
 
 
 def build_iam_policy(config: dict) -> dict:  # noqa: C901
@@ -126,5 +128,19 @@ def build_iam_policy(config: dict) -> dict:  # noqa: C901
                 "\'is_cadet_deployer\' is only valid for CaDeT deployment roles"
             )
         iam["Statement"].extend(iam_lookup["cadet_deployer"])
+
+    if "allowed_database_names" in config:
+        print("testing glue catalog functionality. Hi!")
+        allowed_db_names = config["allowed_database_names"]
+        invalid_db_characters = r"[^a-zA-Z\_\*\s]"
+        glue_catalog_permissions = get_glue_permissions(allowed_db_names)
+        print(glue_catalog_permissions)
+        for db in allowed_db_names:
+            if re.search(invalid_db_characters, db):
+                raise IAMValidationError(
+                    f"Invalid characters in database name: {db}. "
+                    "Only letters, numbers, underscores and asterisks are allowed."
+                )
+        iam["Statement"].append(glue_catalog_permissions)
 
     return iam

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -132,13 +132,13 @@ def build_iam_policy(config: dict) -> dict:  # noqa: C901
     if "allowed_database_names" in config:
         allowed_db_names = config["allowed_database_names"]
         invalid_db_characters = r"[^a-zA-Z\_\*\s]"
-        glue_catalog_permissions = get_glue_permissions(allowed_db_names)
         for db in allowed_db_names:
             if re.search(invalid_db_characters, db):
                 raise IAMValidationError(
                     f"Invalid characters in database name: {db}. "
                     "Only letters, numbers, underscores and asterisks are allowed."
                 )
+        glue_catalog_permissions = get_glue_permissions(allowed_db_names)
         iam["Statement"].append(glue_catalog_permissions)
 
     return iam

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -130,7 +130,6 @@ def build_iam_policy(config: dict) -> dict:  # noqa: C901
         iam["Statement"].extend(iam_lookup["cadet_deployer"])
 
     if "allowed_database_names" in config:
-        print("testing glue catalog functionality. Hi!")
         allowed_db_names = config["allowed_database_names"]
         invalid_db_characters = r"[^a-zA-Z\_\*\s]"
         glue_catalog_permissions = get_glue_permissions(allowed_db_names)

--- a/iam_builder/iam_builder.py
+++ b/iam_builder/iam_builder.py
@@ -134,7 +134,6 @@ def build_iam_policy(config: dict) -> dict:  # noqa: C901
         allowed_db_names = config["allowed_database_names"]
         invalid_db_characters = r"[^a-zA-Z\_\*\s]"
         glue_catalog_permissions = get_glue_permissions(allowed_db_names)
-        print(glue_catalog_permissions)
         for db in allowed_db_names:
             if re.search(invalid_db_characters, db):
                 raise IAMValidationError(

--- a/iam_builder/schemas/iam_schema.json
+++ b/iam_builder/schemas/iam_schema.json
@@ -36,6 +36,13 @@
                 }
             }
         },
+        "allowed_database_names": {
+            "description": "A list of glue database names that the iam_role should be able to access.",
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        },
         "is_cadet_deployer": {
             "description": "is_cadet_deployer should be reserved only for the highly empowered cadet deployment task. Inappropriate for other roles.",
             "type": "boolean"

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -590,3 +590,42 @@ def get_secretsmanager_read_only_policy(secrets: list) -> dict:
         "Resource": allow_list_of_secrets
     }
     return policy
+
+def get_glue_permissions(database_names: list) -> dict:
+    allowed_db_names = [f"arn:aws:glue:*:*:database/{name}" for name in database_names]
+    allowed_db_names.append("arn:aws:glue:*:*:database/alpha_user*")
+    allowed_db_names.append("arn:aws:glue:*:*:catalog")
+    table_names = [f"arn:aws:glue:*:*:table/{name}/*" for name in database_names]
+    table_names.append("arn:aws:glue:*:*:table/alpha_user*/*")
+    policy = {
+        "Sid": "glueCatalogPermissions",
+        "Action": [
+            "glue:GetDatabase",
+            "glue:GetDatabases",
+            "glue:GetTable",
+            "glue:GetTables",
+            "glue:GetTableVersion",
+            "glue:GetTableVersions",
+            "glue:GetPartition",
+            "glue:GetPartitions",
+            "glue:BatchGetPartition",
+            "glue:BatchCreatePartition",
+            "glue:BatchDeletePartition",
+            "glue:BatchDeleteTable",
+            "glue:CreateDatabase",
+            "glue:CreatePartition",
+            "glue:CreateTable",
+            "glue:DeleteDatabase",
+            "glue:DeletePartition",
+            "glue:DeleteTable",
+            "glue:UpdateDatabase",
+            "glue:UpdatePartition",
+            "glue:UpdateTable",
+            "glue:CreateUserDefinedFunction",
+            "glue:DeleteUserDefinedFunction",
+            "glue:UpdateUserDefinedFunction"
+        ],
+        "Effect": "Allow",
+        "Resource": allowed_db_names + table_names
+    }
+    return policy

--- a/iam_builder/templates.py
+++ b/iam_builder/templates.py
@@ -593,10 +593,10 @@ def get_secretsmanager_read_only_policy(secrets: list) -> dict:
 
 def get_glue_permissions(database_names: list) -> dict:
     allowed_db_names = [f"arn:aws:glue:*:*:database/{name}" for name in database_names]
-    allowed_db_names.append("arn:aws:glue:*:*:database/alpha_user*")
+    allowed_db_names.append("arn:aws:glue:*:*:database/mojap_de_temp_alpha_user*")
     allowed_db_names.append("arn:aws:glue:*:*:catalog")
     table_names = [f"arn:aws:glue:*:*:table/{name}/*" for name in database_names]
-    table_names.append("arn:aws:glue:*:*:table/alpha_user*/*")
+    table_names.append("arn:aws:glue:*:*:table/mojap_de_temp_alpha_user*/*")
     policy = {
         "Sid": "glueCatalogPermissions",
         "Action": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "iam_builder"
-version = "4.16.0"
+version = "4.17.0"
 description = "A lil python package to generate iam policies"
 authors = ["Karik Isichei <karik.isichei@digital.justice.gov.uk>"]
 license = "MIT"

--- a/tests/expected_policy/glue_catalog_tables.json
+++ b/tests/expected_policy/glue_catalog_tables.json
@@ -33,11 +33,11 @@
             "Resource": [
                 "arn:aws:glue:*:*:database/example_database_name",
                 "arn:aws:glue:*:*:database/example_wildcard_*",
-                "arn:aws:glue:*:*:database/alpha_user*",
+                "arn:aws:glue:*:*:database/mojap_de_temp_alpha_user*",
                 "arn:aws:glue:*:*:catalog",
                 "arn:aws:glue:*:*:table/example_database_name/*",
                 "arn:aws:glue:*:*:table/example_wildcard_*/*",
-                "arn:aws:glue:*:*:table/alpha_user*/*"
+                "arn:aws:glue:*:*:table/mojap_de_temp_alpha_user*/*"
             ]
         }
     ]

--- a/tests/expected_policy/glue_catalog_tables.json
+++ b/tests/expected_policy/glue_catalog_tables.json
@@ -1,0 +1,44 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "glueCatalogPermissions",
+            "Effect": "Allow",
+            "Action": [
+                "glue:GetDatabase",
+                "glue:GetDatabases",
+                "glue:GetTable",
+                "glue:GetTables",
+                "glue:GetTableVersion",
+                "glue:GetTableVersions",
+                "glue:GetPartition",
+                "glue:GetPartitions",
+                "glue:BatchGetPartition",
+                "glue:BatchCreatePartition",
+                "glue:BatchDeletePartition",
+                "glue:BatchDeleteTable",
+                "glue:CreateDatabase",
+                "glue:CreatePartition",
+                "glue:CreateTable",
+                "glue:DeleteDatabase",
+                "glue:DeletePartition",
+                "glue:DeleteTable",
+                "glue:UpdateDatabase",
+                "glue:UpdatePartition",
+                "glue:UpdateTable",
+                "glue:CreateUserDefinedFunction",
+                "glue:DeleteUserDefinedFunction",
+                "glue:UpdateUserDefinedFunction"
+            ],
+            "Resource": [
+                "arn:aws:glue:*:*:database/example_database_name",
+                "arn:aws:glue:*:*:database/example_wildcard_*",
+                "arn:aws:glue:*:*:database/alpha_user*",
+                "arn:aws:glue:*:*:catalog",
+                "arn:aws:glue:*:*:table/example_database_name/*",
+                "arn:aws:glue:*:*:table/example_wildcard_*/*",
+                "arn:aws:glue:*:*:table/alpha_user*/*"
+            ]
+        }
+    ]
+}

--- a/tests/test_config/bad_glue_catalog_tables.yaml
+++ b/tests/test_config/bad_glue_catalog_tables.yaml
@@ -1,0 +1,5 @@
+iam_role_name: an_iam_role_name
+
+allowed_database_names:
+  - example_invalid_database_name!
+  - example_wildcard_*

--- a/tests/test_config/glue_catalog_tables.yaml
+++ b/tests/test_config/glue_catalog_tables.yaml
@@ -1,0 +1,5 @@
+iam_role_name: an_iam_role_name
+
+allowed_database_names:
+  - example_database_name
+  - example_wildcard_*

--- a/tests/test_iam_builder.py
+++ b/tests/test_iam_builder.py
@@ -60,7 +60,7 @@ class TestConfigOutputs(unittest.TestCase):
     """
     Test different configs
     """
-
+    maxDiff = None
     @parameterized.expand(
         [
             "read_only",
@@ -72,6 +72,7 @@ class TestConfigOutputs(unittest.TestCase):
             "athena_full_access",
             "athena_two_dumps",
             "glue_job",
+            "glue_catalog_tables",
             "cadet_deployer",
             "all_config",
             "secrets",
@@ -94,6 +95,7 @@ class TestBadConfigs(unittest.TestCase):
             ("bad_athena_config", IAMValidationError),
             ("bad_cadet_deployer", PrivilegedRoleValidationError),
             ("bad_glue_config", IAMValidationError),
+            ("bad_glue_catalog_tables", IAMValidationError),
             ("bad_read_only_not_list", IAMValidationError),
             ("bad_s3_config", IAMValidationError),
             ("bad_yaml", ParserError),

--- a/tests/test_iam_builder.py
+++ b/tests/test_iam_builder.py
@@ -60,7 +60,7 @@ class TestConfigOutputs(unittest.TestCase):
     """
     Test different configs
     """
-    maxDiff = None
+
     @parameterized.expand(
         [
             "read_only",


### PR DESCRIPTION
This PR is the start of the path towards our ability to restrict the current glue catalog policy from it's breadth to a more strictly defined set of allowed actions. For the timebeing, this policy is intentionally superceded by the current standard database access policy, and only kicks in if the optional key `allowed_database_names` is supplied. In future, the policy here will be the only way to gain these sort of permissions, but we need to allow time for users to start defining this information. This will need to be accompanied, ideally, by some guidance on best practices for naming conventions, but I am torn on this as this is a required move and I don't want to delay it unnecessarily.